### PR TITLE
feat: add deploy_aggkit_prover flag to support AggKit prover with any…

### DIFF
--- a/input_parser.star
+++ b/input_parser.star
@@ -5,23 +5,33 @@ dict = import_module("./src/package_io/dict.star")
 # You can deploy the whole stack and then only deploy a subset of the components to perform an
 # an upgrade or to test a new version of a component.
 DEFAULT_DEPLOYMENT_STAGES = {
-    # Deploy a local L1 chain using the ethereum-package.
-    # Set to false to use an external L1 like Sepolia.
-    # Note that it will require a few additional parameters.
+    # Deploy local L1.
+    # Set to false to deploy to an external L1.
     "deploy_l1": True,
-    # Deploy zkevm contracts on L1 (as well as fund accounts).
-    # Set to false to use pre-deployed zkevm contracts.
-    # Note that it will require a few additional parameters.
+    # Deploy zkevm contracts on L1 (and also fund accounts).
     "deploy_zkevm_contracts_on_l1": True,
-    # Deploy databases.
+    # Deploy the second and subsequent rollups on L1 (and also fund accounts).
+    # If this is set to false then only the first rollup will be deployed.
+    "deploy_additional_rollup": False,
+    # Deploy helper service to retrieve rollup data.
+    "deploy_rollup_data_helper": True,
+    # Deploy databases (postgres, maybe consul/zookeeper).
     "deploy_databases": True,
-    # Deploy CDK central/trusted environment.
+    # Deploy cdk central/trusted environment (cdk-node, cdk-dac, zkevm-sequence-sender).
     "deploy_cdk_central_environment": True,
-    # Deploy CDK bridge infrastructure.
+    # Deploy cdk/bridge infrastructure (cdk-contracts, bridge-service, bridge-ui).
     "deploy_cdk_bridge_infra": True,
-    # Deploy CDK bridge UI.
+    # Deploy centralized sequencer on L2.
+    "deploy_centralized_sequencer": True,
+    # Deploy permissionless node on L2.
+    "deploy_cdk_permissionless_node": False,
+    # Deploy Marplex environment.
+    "deploy_marplex": False,
+    # Deploy CDK node (cdk-node).
+    # deploy_cdk_node: true
+    # Deploy bridge UI.
     "deploy_cdk_bridge_ui": False,
-    # Deploy the agglayer.
+    # Deploy agglayer.
     "deploy_agglayer": True,
     # Deploy cdk-erigon node.
     # TODO: Remove this parameter to incorporate cdk-erigon inside the central environment.
@@ -34,6 +44,9 @@ DEFAULT_DEPLOYMENT_STAGES = {
     # After deploying OP Stack, upgrade it to OP Succinct.
     # Even mock-verifier deployments require an actual SPN network key.
     "deploy_op_succinct": False,
+    # Deploy AggKit Prover independently of OP Stack
+    # This allows aggkit-prover to be deployed with any consensus type
+    "deploy_aggkit_prover": False,
     # Deploy contracts on L2 (as well as fund accounts).
     "deploy_l2_contracts": False,
 }

--- a/main.star
+++ b/main.star
@@ -259,7 +259,7 @@ def run(plan, args={}):
         plan.print("Skipping the deployment of OP Succinct")
 
     # Deploy AggKit infrastructure + Dedicated Bridge Service
-    if deployment_stages.get("deploy_optimism_rollup", False):
+    if deployment_stages.get("deploy_optimism_rollup", False) or deployment_stages.get("deploy_aggkit_prover", False):
         plan.print("Deploying AggKit infrastructure")
         import_module(aggkit_package).run(
             plan,

--- a/scenarios/type1-aggkit/kurtosis-config.yml
+++ b/scenarios/type1-aggkit/kurtosis-config.yml
@@ -1,0 +1,69 @@
+# Configuration for CDK-Erigon with AggKit Prover
+# Uses the new deploy_aggkit_prover flag to deploy aggkit-prover 
+# independently of OP Stack
+
+deployment_stages:
+  deploy_l1: true
+  deploy_zkevm_contracts_on_l1: true
+  deploy_databases: true
+  deploy_cdk_central_environment: true
+  deploy_cdk_bridge_infra: true
+  deploy_cdk_bridge_ui: false
+  deploy_agglayer: true
+  deploy_cdk_erigon_node: true
+  # Don't deploy OP Stack
+  deploy_optimism_rollup: false
+  deploy_op_succinct: false
+  # Deploy AggKit Prover independently
+  deploy_aggkit_prover: true
+  deploy_l2_contracts: true
+
+args:
+  verbosity: debug
+  
+  # Image versions
+  zkevm_contracts_image: jhkimqd/zkevm-contracts:v10.1.0-rc.5-fork.12
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
+  cdk_node_image: ghcr.io/0xpolygon/cdk:0.5.4-rc1
+  aggkit_image: ghcr.io/agglayer/aggkit:0.3.0-beta6
+  agglayer_image: ghcr.io/agglayer/agglayer:0.3.0-rc.21
+  aggkit_prover_image: ghcr.io/agglayer/aggkit-prover:0.1.0-rc.29
+  
+  # Configure for cdk-erigon as sequencer - using local build
+  sequencer_type: erigon
+  cdk_erigon_node_image: cdk-erigon:local
+  
+  # Consensus type - pessimistic works with aggkit-prover now
+  consensus_contract_type: pessimistic
+  
+  # Verification keys for pessimistic consensus
+  pp_vkey_hash: '0x00e60517ac96bf6255d81083269e72c14ad006e5f336f852f7ee3efb91b966be'
+  pp_vkey_selector: '0x00000002'
+  
+  # AggKit prover configuration
+  aggkit_prover_primary_prover: mock-prover
+  aggkit_prover_log_level: debug
+  
+  # SP1 prover key for aggkit
+  sp1_prover_key: "0x2857ca0e7748448f3a50469f7ffe55cde7299d5696aedd72cfe18a06fb856970"
+  
+  # General configuration
+  erigon_strict_mode: false
+  gas_token_enabled: false
+  zkevm_use_real_verifier: false
+  enable_normalcy: true
+  
+  # Chain configuration
+  chain_name: type1-aggkit
+  zkevm_rollup_chain_id: 2151908
+  zkevm_rollup_id: 1
+  
+  # L1 configuration
+  l1_chain_id: 271828
+  l1_seconds_per_slot: 2
+  l1_preset: minimal
+  l1_funding_amount: "1000000ether"
+  
+  # L2 funding
+  l2_accounts_to_fund: 10
+  l2_funding_amount: "100ether" 

--- a/templates/cdk-erigon/config.yml.original
+++ b/templates/cdk-erigon/config.yml.original
@@ -239,7 +239,9 @@ zkevm.data-stream-port: {{.zkevm_data_stream_port}}
 # - 3: Latest format with additional features
 # Default: 2
 # fork12 or after {{if eq .zkevm_rollup_fork_name "banana"}}
+zkevm.datastream-version: 3
 # before fork12 {{else}}
+zkevm.datastream-version: 2
 # {{end}}
 
 # Maximum time to wait for a new block when requesting from the data streamer.


### PR DESCRIPTION
… consensus type

- Add new deployment flag deploy_aggkit_prover to decouple from OP Stack

- Modify aggkit.star to check for either deploy_aggkit_prover or legacy deploy_op_succinct

- Update main.star to deploy AggKit infrastructure when deploy_aggkit_prover is true

- Configure aggkit-prover to support both CDK-Erigon and OP Stack sequencers

- Add example configuration for CDK-Erigon with AggKit prover using pessimistic consensus

## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
